### PR TITLE
release: prepare v6.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ in the DB.
 
 ### Docs
 
--   [Upgrading](#upgrading)
--   [Installation](#installation)
--   [Configuration](#configuration)
--   [Assets](#assets)
--   [Generators](#generators)
--   [Usage](#usage)
--   [Exceptions](#exceptions)
--   [Laravel compatibility](#laravel-compatibility)
--   [Envoyer deployments](#envoyer-deployments)
+- [Upgrading](#upgrading)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Assets](#assets)
+- [Generators](#generators)
+- [Usage](#usage)
+- [Exceptions](#exceptions)
+- [Laravel compatibility](#laravel-compatibility)
+- [Envoyer deployments](#envoyer-deployments)
 
 ## Upgrading
 
@@ -70,15 +70,16 @@ command below to move the content to the appropriate locations.
 ### Install Command
 
 LaravelCM 2.x features a new install command that takes care of publishing the config files and such.
-However, you can also run this to move your existing template files and layouts to the storage folder so
-they don't get lost after deployments.
+You can also run this during deployments to make sure required directories exist and legacy files are
+migrated to the current directory structure.
 
 ```bash
 php artisan laravel-cm:install --deployment
 ```
 
-This command will only copy the existing template files from the resources folder to storage, delete the
-now empty laravel-cm folder and set a symlink to the newly created storage folder.
+This command keeps layouts in `resources/laravel-cm/layouts` (repository-managed) and stores generated
+template source files in storage (default: `storage/app/laravel-cm/templates`). Existing files are synced
+in a non-destructive way so already existing files are preserved.
 
 ### Upgrade from Version 2.x to Version 3.x
 
@@ -329,6 +330,38 @@ This determines the name of the layout file the package views will extend.
 'layout_file' => 'admin'
 ```
 
+### Layout path
+
+This is the resources path where layouts are stored and loaded from.
+
+```php
+'layout_path' => 'laravel-cm/layouts'
+```
+
+### Template location
+
+Determines where template source files are stored. By default this is set to storage.
+
+```php
+'template_location' => 'storage' // storage|resource
+```
+
+### Template storage path
+
+Storage path used for template source files when `template_location` is set to `storage`.
+
+```php
+'template_storage_path' => 'app/laravel-cm/templates'
+```
+
+### Template path (legacy resource mode)
+
+Resources path used when `template_location` is set to `resource`.
+
+```php
+'template_path' => 'laravel-cm/templates'
+```
+
 ### Max test emails
 
 Maximum number of preview test email addresses.
@@ -484,7 +517,8 @@ exist.
 
 | Laravel | LaravelCM     |
 | :------ | :------------ |
-| 11.x    | >6.0.\*       |
+| 12.x    | >6.1.\*       |
+| 11.x    | >6.1.\*       |
 | 10.x    | >5.0.\*       |
 | 9.x     | >4.0.\*       |
 | 8.x     | >3.0.\*       |
@@ -509,5 +543,5 @@ need to do is run the following command:
 php artisan laravel-cm:install --deployment
 ```
 
-This will run a function that moves all existing stuff to the new installation and takes care
-of recreating the necessary symlinks for everything to work.
+This will ensure required directories exist and perform a backward-compatible migration:
+layouts are kept in resources, templates are synced to storage, and existing files are not overwritten.

--- a/changelog.md
+++ b/changelog.md
@@ -1,43 +1,69 @@
 ## Version History
 
+### v. 6.1.3
+
+- Switched default template source location to storage while keeping layouts in resources
+- Added `template_location` and `template_storage_path` configuration options
+- Updated install/deployment migration to preserve existing files and avoid overwriting layouts/templates
+- Removed legacy full `resources/laravel-cm` symlink workflow in favor of split layout/template handling
+
+### v. 6.1.2
+
+- Fixed a hardcoded path in the stubs
+- Updated Readme
+- Updated a few titles with translated strings
+
+### v. 6.1.1
+
+- Addresses an issue where SASS files weren't handled correctly by the RemoteCompiler class
+
+### v. 6.1.0
+
+- Fixed remote compiler to be compatible with new version
+
+### v. 6.0.1
+
+- Added support for Laravel 12
+- Fixed old validation code
+
 ### v. 6.0.0
 
--   Added support for Laravel 11
+- Added support for Laravel 11
 
 ### v. 5.0.0
 
--   Added support for Laravel 10
+- Added support for Laravel 10
 
 ### v. 4.0.3
 
--   Fixed dashboard problem
+- Fixed dashboard problem
 
 ### v. 4.0.2
 
--   Fixed route issue
+- Fixed route issue
 
 ### v. 4.0.1
 
--   Fixed storage issue
+- Fixed storage issue
 
 ### v. 4.0.0
 
--   Initial Laravel 9 support
+- Initial Laravel 9 support
 
 ### v. 3.0.3
 
--   PHP 8 updates
+- PHP 8 updates
 
 ### v. 3.0.2
 
--   Removed implicit dependency on Laravel Breeze
--   Added custom drop down and menu items
+- Removed implicit dependency on Laravel Breeze
+- Added custom drop down and menu items
 
 ### v. 3.0.1
 
--   Added a responsive menu snippet for Tailwind
+- Added a responsive menu snippet for Tailwind
 
 ### v. 3.0.0
 
--   Added support for Laravel 8
--   Added support for TailwindCSS
+- Added support for Laravel 8
+- Added support for TailwindCSS

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "flobbos/laravel-cm",
+    "version": "6.1.3",
     "description": "Complete package for Campaign Monitor integration",
     "keywords": [
         "laravel",

--- a/src/LaravelCM/Commands/InstallCommand.php
+++ b/src/LaravelCM/Commands/InstallCommand.php
@@ -29,37 +29,90 @@ class InstallCommand extends Command
 
     protected $type = 'Installation';
 
+    protected function ensureDirectory(string $path)
+    {
+        if (!File::exists($path)) {
+            File::makeDirectory($path, 0755, true);
+        }
+    }
+
+    protected function copyMissingFiles(string $source, string $target)
+    {
+        if (!File::isDirectory($source)) {
+            return;
+        }
+
+        $this->ensureDirectory($target);
+
+        foreach (File::allFiles($source) as $file) {
+            $relativePath = ltrim(str_replace($source, '', $file->getPathname()), DIRECTORY_SEPARATOR);
+            $targetFile = rtrim($target, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
+            $targetDir = dirname($targetFile);
+
+            if (!File::exists($targetDir)) {
+                File::makeDirectory($targetDir, 0755, true);
+            }
+
+            if (!File::exists($targetFile)) {
+                File::copy($file->getPathname(), $targetFile);
+            }
+        }
+    }
+
     protected function generateSymlinks()
     {
-        //Check for existing layouts in resource path and move it
-        if (File::exists(resource_path('laravel-cm')) && !is_link(resource_path('laravel-cm'))) {
-            $this->info('Moving existing files to storage.');
-            //Create basic laravel-cm directory first
-            if (!File::exists(storage_path('app/laravel-cm'))) {
-                File::makeDirectory(storage_path('app/laravel-cm/'));
+        $resourceRoot = resource_path('laravel-cm');
+        $layoutPath = resource_path(config('laravel-cm.layout_path'));
+        $resourceTemplatePath = resource_path(config('laravel-cm.template_path'));
+        $storageTemplatePath = storage_path(config('laravel-cm.template_storage_path', 'app/laravel-cm/templates'));
+        $legacyStorageRoot = storage_path('app/laravel-cm');
+        $legacyLayoutPath = $legacyStorageRoot . '/layouts';
+        $legacyTemplatePath = $legacyStorageRoot . '/templates';
+
+        // Remove legacy symlink of resources/laravel-cm -> storage/app/laravel-cm
+        if (is_link($resourceRoot)) {
+            $linkTarget = readlink($resourceRoot);
+            $resolvedLinkTarget = $linkTarget ? realpath($linkTarget) : false;
+            $resolvedLegacyStorageRoot = realpath($legacyStorageRoot);
+
+            if (
+                $linkTarget === $legacyStorageRoot ||
+                ($resolvedLinkTarget && $resolvedLegacyStorageRoot && $resolvedLinkTarget === $resolvedLegacyStorageRoot)
+            ) {
+                @unlink($resourceRoot);
+                $this->info('Removed legacy resources symlink for laravel-cm.');
             }
-            //Move all existing directories over
-            foreach (File::directories(resource_path('laravel-cm')) as $directory) {
-                File::moveDirectory($directory, storage_path('app/laravel-cm/' . basename($directory)),true);
-            }
-            //Delete now empty directory in resources
-            File::deleteDirectory(resource_path('laravel-cm'));
-            $this->info('All files moved.');
         }
+
+        // Layouts are now repository-managed under resources
+        $this->ensureDirectory($resourceRoot);
+        $this->ensureDirectory($layoutPath);
+
+        // Backward compatibility: preserve and migrate old storage layouts without overwriting repo files
+        if (File::isDirectory($legacyLayoutPath)) {
+            $this->copyMissingFiles($legacyLayoutPath, $layoutPath);
+            $this->info('Synced legacy layouts from storage to resources (existing files preserved).');
+        }
+
+        // Templates are now storage-managed by default
+        $this->ensureDirectory($storageTemplatePath);
+
+        // Backward compatibility: migrate existing templates from old locations without overwriting storage files
+        if (File::isDirectory($resourceTemplatePath) && !is_link($resourceTemplatePath)) {
+            $this->copyMissingFiles($resourceTemplatePath, $storageTemplatePath);
+            $this->info('Synced existing resource templates to storage (existing files preserved).');
+        }
+
+        if (File::isDirectory($legacyTemplatePath)) {
+            $this->copyMissingFiles($legacyTemplatePath, $storageTemplatePath);
+        }
+
         //Check for existing public files and move to storage
         if (File::exists(public_path(config('laravel-cm.asset_path'))) && !is_link(public_path(config('laravel-cm.asset_path')))) {
             $this->info('Moving existing public files to storage.');
             File::moveDirectory(public_path(config('laravel-cm.asset_path')), storage_path('app/public/' . config('laravel-cm.asset_path')));
         }
-        //Check if files in storage exist
-        if (File::exists(storage_path('app/laravel-cm')) && !File::exists(resource_path('laravel-cm'))) {
-            symlink(storage_path('app/laravel-cm'), resource_path('laravel-cm'));
-            $this->info('Generated symlink to LaravelCM files.');
-        } elseif (!File::exists(storage_path('app/laravel-cm'))) {
-            Storage::makeDirectory('laravel-cm');
-            symlink(storage_path('app/laravel-cm'), resource_path('laravel-cm'));
-            $this->info('Created storage directory and symlink.');
-        }
+
         //Check if public assets directory exists
         if (!File::exists(storage_path('app/public/' . config('laravel-cm.asset_path')))) {
             Storage::makeDirectory('public/' . config('laravel-cm.asset_path'));

--- a/src/LaravelCM/Commands/LayoutCommand.php
+++ b/src/LaravelCM/Commands/LayoutCommand.php
@@ -6,7 +6,8 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
-class LayoutCommand extends GeneratorCommand {
+class LayoutCommand extends GeneratorCommand
+{
 
     /**
      * The name and signature of the console command.
@@ -27,7 +28,8 @@ class LayoutCommand extends GeneratorCommand {
      *
      * @return string
      */
-    protected function getStub() {
+    protected function getStub()
+    {
 
         $src = $this->getPath('base');
 
@@ -46,7 +48,8 @@ class LayoutCommand extends GeneratorCommand {
      *
      * @return boolean
      */
-    protected function generateFresh() {
+    protected function generateFresh()
+    {
         return $this->option('fresh');
     }
 
@@ -54,7 +57,8 @@ class LayoutCommand extends GeneratorCommand {
      * Get path-info for given layout-name
      */
 
-    protected function getPathInput() {
+    protected function getPathInput()
+    {
         return trim($this->argument('name'));
     }
 
@@ -64,8 +68,9 @@ class LayoutCommand extends GeneratorCommand {
      * @param  string  $name
      * @return string
      */
-    protected function getPath($name) {
-        return resource_path('laravel-cm/layouts/' . $this->getDirectoryName($name));
+    protected function getPath($name)
+    {
+        return resource_path(config('laravel-cm.layout_path') . '/' . $this->getDirectoryName($name));
     }
 
     /**
@@ -74,7 +79,8 @@ class LayoutCommand extends GeneratorCommand {
      * @param string $name
      * @return string
      */
-    protected function getDirectoryName($name) {
+    protected function getDirectoryName($name)
+    {
         return strtolower(Str::kebab($name));
     }
 
@@ -84,7 +90,8 @@ class LayoutCommand extends GeneratorCommand {
      * @param  string $rawName
      * @return bool
      */
-    protected function alreadyExists($rawName = '') {
+    protected function alreadyExists($rawName = '')
+    {
         return $this->files->exists($this->getPath($this->getPathInput()));
     }
 
@@ -93,7 +100,8 @@ class LayoutCommand extends GeneratorCommand {
      *
      * @return boolean
      */
-    protected function baseNotPublished() {
+    protected function baseNotPublished()
+    {
         return $this->files->exists($this->getPath('base'));
     }
 
@@ -102,7 +110,8 @@ class LayoutCommand extends GeneratorCommand {
      *
      * @return mixed
      */
-    protected function publishBaseLayout() {
+    protected function publishBaseLayout()
+    {
         $this->info('Base-Layout created successfully.');
         return $this->files->copyDirectory(__DIR__ . '/../../resources/defaults/base/', $this->getPath(strtolower('base')));
     }
@@ -112,11 +121,12 @@ class LayoutCommand extends GeneratorCommand {
      *
      * @return mixed
      */
-    public function handle() {
+    public function handle()
+    {
 
         $this->info('WELCOME TO LARAVEL-CM');
 
-        if(!config('laravel-cm.multi_layout')){
+        if (!config('laravel-cm.multi_layout')) {
             $this->error('Your config is set to single layout. Generating a new layout will not make a difference.');
             exit;
         }
@@ -129,7 +139,7 @@ class LayoutCommand extends GeneratorCommand {
         if (!$this->baseNotPublished()) {
 
             // Ask for generate base-layout
-            $publish_base = $this->ask('Base-Layout not published! Should it be published now?',true);
+            $publish_base = $this->ask('Base-Layout not published! Should it be published now?', true);
 
             if (!$publish_base) {
                 $this->error('Base-Layout was not generated. Layouts can only be generated if the base-layout exists.');
@@ -160,5 +170,4 @@ class LayoutCommand extends GeneratorCommand {
 
         $this->info('Layout created successfully.');
     }
-
 }

--- a/src/LaravelCM/LaravelCMServiceProvider.php
+++ b/src/LaravelCM/LaravelCMServiceProvider.php
@@ -4,6 +4,7 @@ namespace Flobbos\LaravelCM;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\File;
 use Illuminate\Foundation\AliasLoader;
 
 class LaravelCMServiceProvider extends ServiceProvider
@@ -93,8 +94,16 @@ class LaravelCMServiceProvider extends ServiceProvider
       'url' => env('APP_URL') . '/storage/laravel-cm-assets',
       'visibility' => 'public'
     ]]);
-    // Register template-location
-    $this->app['view']->addLocation(resource_path(config('laravel-cm.template_path')));
+    // Register template locations (storage first, resource fallback)
+    $templatePaths = [
+      storage_path(config('laravel-cm.template_storage_path', 'app/laravel-cm/templates')),
+      resource_path(config('laravel-cm.template_path')),
+    ];
+    foreach ($templatePaths as $templatePath) {
+      if (File::isDirectory($templatePath)) {
+        $this->app['view']->addLocation($templatePath);
+      }
+    }
     //Grab loader and register static routes facade
     $loader = AliasLoader::getInstance();
     $loader->alias('CMRoutes', 'Flobbos\LaravelCM\Facades\CMRoutes');

--- a/src/LaravelCM/Templates.php
+++ b/src/LaravelCM/Templates.php
@@ -27,7 +27,7 @@ class Templates implements TemplateContract
     {
 
         $this->disk = Storage::disk('laravel_cm');
-        $this->srcTemplatePath = $this->getTemplatePath();
+        $this->srcTemplatePath = $this->getTemplateBasePath();
         $this->template_db = $template_db;
     }
 
@@ -99,7 +99,7 @@ class Templates implements TemplateContract
             //Delete public assets
             $this->disk->deleteDirectory(Str::slug($model->template_name));
             //Delete resource files
-            File::deleteDirectory($this->srcTemplatePath . '/' . Str::slug($model->template_name));
+            File::deleteDirectory($this->getTemplatePath(Str::slug($model->template_name)));
             return $model->delete();
         }
         return false;
@@ -192,7 +192,7 @@ class Templates implements TemplateContract
     public function templateExists(string $template)
     {
         if (!File::exists($this->getTemplatePath($template))) {
-            throw new TemplateNotFoundException('Given template "' . $template . '" not found at ' . resource_path('laravel-cm'));
+            throw new TemplateNotFoundException('Given template "' . $template . '" not found at ' . $this->getTemplateBasePath());
         }
         return true;
     }
@@ -254,7 +254,7 @@ class Templates implements TemplateContract
         }
     }
 
-    private function generateTemplate(string $layout = null)
+    private function generateTemplate(?string $layout = null)
     {
         // Copy stub to new template
         $stubPath = $this->getLayoutPath($layout);
@@ -313,7 +313,7 @@ class Templates implements TemplateContract
         return $resource_files;
     }
 
-    private function getLayoutPath(string $layout = null)
+    private function getLayoutPath(?string $layout = null)
     {
         if (!$layout) {
             $layout = config('laravel-cm.base_layout', 'base');
@@ -321,9 +321,25 @@ class Templates implements TemplateContract
         return resource_path(config('laravel-cm.layout_path') . '/' . $layout);
     }
 
-    private function getTemplatePath()
+    private function getTemplateBasePath()
     {
-        return resource_path(config('laravel-cm.template_path') . '/' . $this->getTemplate());
+        if (config('laravel-cm.template_location', 'storage') === 'resource') {
+            return resource_path(config('laravel-cm.template_path'));
+        }
+
+        return storage_path(config('laravel-cm.template_storage_path', 'app/laravel-cm/templates'));
+    }
+
+    private function getTemplatePath(?string $template = null)
+    {
+        $name = $template ?: $this->getTemplate();
+        $basePath = $this->getTemplateBasePath();
+
+        if (!$name) {
+            return $basePath;
+        }
+
+        return rtrim($basePath, '/') . '/' . $name;
     }
 
     private function getImagePath()

--- a/src/config/laravel-cm.php
+++ b/src/config/laravel-cm.php
@@ -16,12 +16,16 @@ return [
     'storage_path' => 'xls',
     //URL path where to load api
     'url_path' => 'newsletters',
-    //Folder where you want to keep your templates
+    //Folder where you want to keep your layouts (resources path)
     'layout_path' => 'laravel-cm/layouts',
     //Default layout
     'base_layout' => 'base',
-    //Folder where you want to keep your templates
+    //Legacy folder where templates are stored when template_location=resource
     'template_path' => 'laravel-cm/templates',
+    //Where template source files are stored: storage|resource
+    'template_location' => 'storage',
+    //Storage path for template source files when template_location=storage
+    'template_storage_path' => 'app/laravel-cm/templates',
     //Default format to use JSON|XML
     'format' => 'json',
     //Confirmation emails


### PR DESCRIPTION
- Switched default template source location to storage while keeping layouts in resources
- Added `template_location` and `template_storage_path` configuration options
- Updated install/deployment migration to preserve existing files and avoid overwriting layouts/templates
- Removed legacy full `resources/laravel-cm` symlink workflow in favor of split layout/template handling