### PR TITLE
Fixed some path issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 ## Version History
 
+### v. 6.1.4
+
+- Fixed single-layout mode to enforce default layout when no layout is specified
+- Restored `public/storage` symlink creation in install command (fixes inaccessible compiled templates)
+- Updated generated controller stub to use correct storage path for template files
+- Hardened layout resolution in Templates service with null-safe lookups
+
 ### v. 6.1.3
 
 - Switched default template source location to storage while keeping layouts in resources

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "flobbos/laravel-cm",
-    "version": "6.1.3",
+    "version": "6.1.4",
     "description": "Complete package for Campaign Monitor integration",
     "keywords": [
         "laravel",

--- a/src/LaravelCM/Commands/InstallCommand.php
+++ b/src/LaravelCM/Commands/InstallCommand.php
@@ -118,6 +118,13 @@ class InstallCommand extends Command
             Storage::makeDirectory('public/' . config('laravel-cm.asset_path'));
             $this->info('Created public directory for assets.');
         }
+
+        // Ensure Laravel's public storage symlink exists for serving compiled templates
+        $publicStorage = public_path('storage');
+        if (!is_link($publicStorage) && !File::exists($publicStorage)) {
+            Artisan::call('storage:link');
+            $this->info('Created public/storage symlink.');
+        }
     }
 
     /**

--- a/src/LaravelCM/Templates.php
+++ b/src/LaravelCM/Templates.php
@@ -48,6 +48,10 @@ class Templates implements TemplateContract
      */
     public function create(array $data)
     {
+        if (!config('laravel-cm.multi_layout') && empty($data['layout'])) {
+            $data['layout'] = config('laravel-cm.base_layout', 'base');
+        }
+
         return $this->template_db->create($data);
     }
 
@@ -58,6 +62,10 @@ class Templates implements TemplateContract
      */
     public function update($id, array $data, $return_model = false)
     {
+        if (!config('laravel-cm.multi_layout') && empty($data['layout'])) {
+            $data['layout'] = config('laravel-cm.base_layout', 'base');
+        }
+
         $model = $this->find($id);
         if ($return_model) {
             $model->update($data);
@@ -146,8 +154,15 @@ class Templates implements TemplateContract
         //Set template
         $this->setTemplate($template_name);
 
-        if (!File::exists($this->getTemplatePath($template_name)) || Arr::get($data['template']->getChanges(), 'layout')) {
-            $this->generateTemplate($data['template']->layout ?? config('laravel-cm.base_layout', 'base'));
+        $templateModel = Arr::get($data, 'template');
+        $layoutChanged = $templateModel ? Arr::get($templateModel->getChanges(), 'layout') : false;
+        $layout = Arr::get($data, 'template.layout', config('laravel-cm.base_layout', 'base'));
+        if (!$layout) {
+            $layout = config('laravel-cm.base_layout', 'base');
+        }
+
+        if (!File::exists($this->getTemplatePath($template_name)) || $layoutChanged) {
+            $this->generateTemplate($layout);
         }
         //Check if template exists
         $this->templateExists($template_name);

--- a/src/config/laravel-cm.php
+++ b/src/config/laravel-cm.php
@@ -3,7 +3,7 @@
 
 return [
     //Multi layout option
-    'multi_layout' => false,
+    'multi_layout' => true,
     //Your client API Key from CM
     'client_api_key' => 'your secret key',
     //The client ID from CM

--- a/src/resources/stubs/controllers/template_controller.stub
+++ b/src/resources/stubs/controllers/template_controller.stub
@@ -57,6 +57,9 @@ class DummyClass extends Controller
         $request->validate($this->templates->getValidationRulesStore());
 
         $templateData = $request->except(['_token']);
+        if (!config('laravel-cm.multi_layout')) {
+            $templateData['layout'] = config('laravel-cm.base_layout', 'base');
+        }
         $templateData['template_name'] = Str::slug($templateData['template_name']);
         $template = $this->templates->create($templateData);
 
@@ -81,8 +84,7 @@ class DummyClass extends Controller
             $this->templates->compile($template->template_name, [
                 'template' => $template
             ]);
-            $template_path = public_path('laravel-cm-assets/' . $template->template_name . '/' . $template->template_name . '.html');
-            return File::get($template_path);
+            return File::get($template->template_file_path);
         } catch (Exception $ex) {
             return redirect()->back()->withErrors($ex->getMessage());
         }
@@ -118,6 +120,9 @@ class DummyClass extends Controller
         $request->validate($this->templates->getValidationRulesUpdate());
 
         $templateData = $request->except(['_token']);
+        if (!config('laravel-cm.multi_layout')) {
+            $templateData['layout'] = config('laravel-cm.base_layout', 'base');
+        }
         $template = $this->templates->update($id, $templateData, true);
 
         $this->templates->compile($template->template_name, [


### PR DESCRIPTION
- Fixed single-layout mode to enforce default layout when no layout is specified
- Restored `public/storage` symlink creation in install command (fixes inaccessible compiled templates)
- Updated generated controller stub to use correct storage path for template files
- Hardened layout resolution in Templates service with null-safe lookups